### PR TITLE
Fix modman --tutorial for Mac OS users.

### DIFF
--- a/modman
+++ b/modman
@@ -177,7 +177,11 @@ elif [ "$1" = "--help" -o "$1" = "" ]; then
 ###########################
 # Handle "--tutorial" command
 elif [ "$1" = "--tutorial" ]; then
-  echo -e "$tutorial" | less; exit 0
+  pager=$(which pager)                                                                                                  
+  if [ -n $pager ]; then                                                                                                
+      pager=less                                                                                                        
+  fi                                                                                                                    
+  echo -e "$tutorial" | $pager; exit 0
 ###########################
 # Handle "--version" command
 elif [ "$1" = "--version" ]; then


### PR DESCRIPTION
Mac OS by default doesn't have `alias pager="less"` or similar. Fixes #9.
