### PR TITLE
Add configurable module directory

### DIFF
--- a/modman
+++ b/modman
@@ -257,7 +257,7 @@ get_basedir ()
 }
 
 ###############################################################
-# Writes a file, setting the base directory for a module
+# Writes a file, setting the modules directory
 set_basedir ()
 {
   local module_dir=$1


### PR DESCRIPTION
Hi,

I added the ability to specify a module directory where all the modules are stored. The path is stored just like basedir in `.modman/.modulesdir`.

I've changed `modman init` to accept the modules directory as an optional second parameter.

I still don't know how to add the optional parameter to `modman --help`. There is just not enough space after `modman init`.

So e.g.

``` plaintext
------------------------------
  init [basedir] [moddir] initialize the pwd (or [basedir]) as the modman deploy root
  list [--absolute]  list all valid modules that are currently checked out
  status             show VCS 'status' command for all modules
[...]
```

Any hints on this?
