### PR TITLE
remove_dead_links on new link slows down the link process

### DIFF
--- a/modman
+++ b/modman
@@ -882,7 +882,6 @@ case "$action" in
       if [ -d "$wc_dir" ]; then rm -rf "$wc_dir"; fi
       echo "Error trying to $action new module '$module', operation cancelled."
     fi
-    remove_dead_links
     ;;
 
   deploy)


### PR DESCRIPTION
Is there a reason why this is being ran when we have `modman clean`?
