### PR TITLE
Hide error message if pager is not available

### DIFF
--- a/modman
+++ b/modman
@@ -185,7 +185,7 @@ darwin_stat ()
     *) echo unknown_type;;
   esac
 }
-pager=${PAGER:-$(which pager)}
+pager=${PAGER:-$(which pager &> /dev/null)}
 if [ -n $pager ]; then
   pager=less
 fi


### PR DESCRIPTION
Currently, there will be a message "which: no pager in (/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin)" if pager is not available. This pull request hides this message.
