### PR TITLE
Small fix: Support for $PAGER to have parameters

### DIFF
--- a/modman
+++ b/modman
@@ -200,7 +200,7 @@ bsd_stat ()
   esac
 }
 pager=${PAGER:-$(which pager &> /dev/null)}
-if [ -n $pager ]; then
+if [ -n "$pager" ]; then
   pager=less
 fi
 


### PR DESCRIPTION
If `$PAGER` contains any parameter, bash will complain. The solution is easy: Just wrap around double quotes.
