### PR TITLE
Add 'bin' section to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,6 @@
         {
             "name": "Colin Mollenhour"
         }
-    ]
+    ],
+    "bin": ["modman"]
 }


### PR DESCRIPTION
Adding the modman script to the bin section allows composer to symlink the script into the common vendor binary directory on install
