### PR TITLE
added missing quotes to avoid bash error

### DIFF
--- a/modman
+++ b/modman
@@ -704,7 +704,7 @@ run_automodman () #"$module" "$mm" "$wc_dir" "$wc_desc"
 get_tracking_branch ()
 {
   local tracking_branch=$(git rev-parse --symbolic-full-name --abbrev-ref @{u} 2> /dev/null)
-  if [ -n $tracking_branch -a "$tracking_branch" != "@{u}" ]; then
+  if [ -n "$tracking_branch" -a "$tracking_branch" != "@{u}" ]; then
     echo $tracking_branch
   fi
 }


### PR DESCRIPTION
Function `get_tracking_branch` produces a bash error if a local branch has no remote tracking branch.
In this case 
`-n $tracking_branch`
produces an error because of missing argument for `-n`
We have to use
`-n "$tracking_branch"`
instead to be safe.