### PR TITLE
Make sure .modman-skip file exists

### DIFF
--- a/modman
+++ b/modman
@@ -348,12 +348,13 @@ set_basedir ()
 get_skipped ()
 {
   local module=$1
-  for line in $(grep -v -e '^#' "$root/.modman-skip"); do
-    if [ $line == $module ]; then
-      return 0
-    fi
-  done
-
+  if [ -f "$root/.modman-skip" ]; then
+    for line in $(grep -v -e '^#' "$root/.modman-skip"); do
+      if [ $line == $module ]; then
+        return 0
+      fi
+    done
+  fi
   return 1
 }
 


### PR DESCRIPTION
If the file does not exists, grep error messages will be shown. This fix assures that the .modman-skip file really exists before trying to run the grep command.

```
grep: /absolute/path/to/target/src/magento/.modman-skip: No such file or directory
Deploying Ebizmarts to /absolute/path/to/target/src/magento
Deployment of 'Ebizmarts' complete.
```