### PR TITLE
Add --modmandir option.

### DIFF
--- a/modman
+++ b/modman
@@ -29,45 +29,46 @@ Module Manager (v$version)
 Global Commands:
   $script <command> [<options>]
 ------------------------------
-  init [basedir]     initialize the pwd (or [basedir]) as the modman deploy root
-  list [--absolute]  list all valid modules that are currently checked out
-  status             show VCS 'status' command for all modules
-  incoming           show new VCS remote changesets for all VCS-based modules
-  update-all         update all modules that are currently checked out
-  deploy-all         deploy all modules (no VCS interaction)
-  repair             rebuild all modman-created symlinks (no updates performed)
-  clean              clean up broken symlinks (run this after deleting a module)
-  automodman         loops through module directory:
-                     - asks to include files & directories in new modman file
-                     - does not create symlinks
-  --help             display this help message
-  --tutorial         show a brief tutorial on using modman
-  --version          display the modman script's version
-  [--force]          overwrite existing files, ignore untrusted cert warnings
-  [--no-local]       skip processing of modman.local files
-  [--no-clean]       skip cleaning of broken symlinks
-  [--no-shell]       skip processing @shell lines
+  init [basedir] [modmandir] initialize the pwd (or [basedir]) as the modman deploy root
+  list [--absolute]          list all valid modules that are currently checked out
+  status                     show VCS 'status' command for all modules
+  incoming                   show new VCS remote changesets for all VCS-based modules
+  update-all [modmandir]     update all modules that are currently checked out
+  deploy-all                 deploy all modules (no VCS interaction)
+  repair                     rebuild all modman-created symlinks (no updates performed)
+  clean                      clean up broken symlinks (run this after deleting a module)
+  automodman                 loops through module directory:
+                              - asks to include files & directories in new modman file
+                              - does not create symlinks
+  --help                     display this help message
+  --tutorial                 show a brief tutorial on using modman
+  --version                  display the modman script's version
+  [--force]                  overwrite existing files, ignore untrusted cert warnings
+  [--no-local]               skip processing of modman.local files
+  [--no-clean]               skip cleaning of broken symlinks
+  [--no-shell]               skip processing @shell lines
 
 Module Commands:
   $script <command> [<module>] [<options>] [[--] <VCS options>]
 ------------------------------
-  checkout <src>     checkout a new modman-compatible module using subversion
-  clone <src>        checkout a new modman-compatible module using git clone
-  hgclone <src>      checkout a new modman-compatible module using hg clone
-  link <path>        link to a module that already exists on the local filesystem
-  update             update module using the appropriate VCS
-  deploy             deploy an existing module (VCS not required or used)
-  undeploy           remove an existing module without deleting the files
-  skip               prevent a module from deploying with deploy-all
-  unskip             re-enable a module to be deployed with deploy-all
-  remove             remove a module (DELETES MODULE FILES)
-  [--force]          overwrite existing files, ignore untrusted cert warnings
-  [--no-local]       skip processing of modman.local files
-  [--no-clean]       skip cleaning of broken symlinks
-  [--no-shell]       skip processing @shell lines
-  [--basedir <path>] on checkout/clone, specifies a base for module deployment
-  [--copy]           deploy by copying files instead of symlinks
-  [<VCS options>]    specify additional parameters to VCS checkout/clone
+  checkout <src>        checkout a new modman-compatible module using subversion
+  clone <src>           checkout a new modman-compatible module using git clone
+  hgclone <src>         checkout a new modman-compatible module using hg clone
+  link <path>           link to a module that already exists on the local filesystem
+  update                update module using the appropriate VCS
+  deploy                deploy an existing module (VCS not required or used)
+  undeploy              remove an existing module without deleting the files
+  skip                  prevent a module from deploying with deploy-all
+  unskip                re-enable a module to be deployed with deploy-all
+  remove                remove a module (DELETES MODULE FILES)
+  [--force]             overwrite existing files, ignore untrusted cert warnings
+  [--no-local]          skip processing of modman.local files
+  [--no-clean]          skip cleaning of broken symlinks
+  [--no-shell]          skip processing @shell lines
+  [--modmandir <path>]  the modman folder commands should be ran for]
+  [--basedir <path>]    on checkout/clone, specifies a base for module deployment
+  [--copy]              deploy by copying files instead of symlinks
+  [<VCS options>]       specify additional parameters to VCS checkout/clone
 "
 tutorial="\
 Deploying a modman module:
@@ -216,10 +217,11 @@ fi
 # Handle "init" command, simply create .modman directory
 if [ "$action" = "init" ]; then
   basedir=$1
+  [[ -n "$2" ]] &&  modmandir="$2" || modmandir=".modman"
   [[ -n "$basedir" && ! -d "$basedir" ]] && { echo "$basedir is not a directory."; exit 1; }
-  mkdir .modman || { echo "Could not create .modman directory" && exit 1; }
+  mkdir "$modmandir" || { echo "Could not create $modmandir directory" && exit 1; }
   if [ -n "$basedir" ]; then
-    echo "$basedir" > .modman/.basedir
+    echo "$basedir" > "$modmandir/.basedir"
     basedir="with basedir at $basedir"
   fi
   echo "Initialized Module Manager at $(pwd) $basedir"
@@ -714,28 +716,10 @@ get_tracking_branch ()
 }
 
 ################################
-# Find the .modman directory and store parent path in $root
+# Find the .modman directory
 mm_not_found="Module Manager directory not found.\nRun \"$script init\" in the root of the project with which you would like to use Module Manager."
 _pwd=$(pwd -P)
 root=$_pwd
-while ! [ -d "$root/.modman" ]; do
-  if [ "$root" = "/" ]; then echo -e $mm_not_found && exit 1; fi
-  cd .. || { error "Could not traverse up from $root\n$mm_not_found" && exit 1; }
-  root=$(pwd)
-done
-
-mmroot=$root          # parent of .modman directory
-mm=$root/.modman      # path to .modman
-
-# Allow a different root to be specified as root for deploying modules, applies to all modules
-newroot=$(get_basedir "$mm")
-if [ -n "$newroot" ]; then
-  cd "$mmroot/$newroot" || {
-    error "Could not change to basedir specified in .basedir file: $newroot"
-    exit 1
-  }
-  root=$(pwd)
-fi
 
 # Check for common option overrides
 FORCE=0               # --force option off by default
@@ -743,6 +727,7 @@ NOLOCAL=0             # --no-local option off by default
 NOCLEAN=0             # --no-clean off by default
 NOSHELL=0             # --no-shell option off by default
 COPY=0                # --copy option off by default
+modmandir='.modman'   # --modmandir defaults to .modman
 basedir=''
 while true; do
   case "$1" in
@@ -757,9 +742,36 @@ while true; do
         echo "Specified --basedir does not exist: $basedir"; exit 1
       fi
       ;;
+    --modmandir)
+      shift; modmandir="$1"; shift
+      if ! [ -n "$modmandir" -a -d "$root/$modmandir" ]; then
+        echo "Specified --modmandir does not exist; $modmandir"; exit 1
+      fi
+      ;;
     *) break ;;
   esac
 done
+
+################################
+# Store modman parent path in $root
+while ! [ -d "$root/$modmandir" ]; do
+  if [ "$root" = "/" ]; then echo -e $mm_not_found && exit 1; fi
+  cd .. || { error "Could not traverse up from $root\n$mm_not_found" && exit 1; }
+  root=$(pwd)
+done
+
+mmroot=$root          # parent of .modman directory
+mm="$root/$modmandir" # path to .modman
+
+# Allow a different root to be specified as root for deploying modules, applies to all modules
+newroot=$(get_basedir "$mm")
+if [ -n "$newroot" ]; then
+  cd "$mmroot/$newroot" || {
+    error "Could not change to basedir specified in .basedir file: $newroot"
+    exit 1
+  }
+  root=$(pwd)
+fi
 
 ###############################
 # Handle "list" command
@@ -1169,7 +1181,7 @@ case "$action" in
       if [ "${src:0:1}" != "/" ]; then
         src="../$src"
       fi
-      ln -s "$src" ".modman/$module" && success=1
+      ln -s "$src" "$modmandir/$module" && success=1
       cd "$mm"
     fi
 


### PR DESCRIPTION
Specifying --modmandir allows control over where modman will place /
source code from. Effectively allowing multiple modman directories for a
single install. Refs #87.