### PR TITLE
No relative links into symlinked dirs

### DIFF
--- a/modman
+++ b/modman
@@ -389,6 +389,17 @@ set_skipped ()
   return 0
 }
 
+# Check if there is a symlink in a directory-path (e.g. b is a symlink, within a/b/c)
+is_symlink_path() {
+  local d="."
+  local IFS=/;
+  for p in $1; do
+    d="$d/$p"
+    [ -h "$d" ] && return 0
+  done
+  return 1
+}
+
 get_abs_filename() {
   if [ -d "$(dirname "$1")" ]; then
     echo "$(cd "$(dirname "$1")/$(dirname "$(readlink "$1")")" && pwd)/$(basename "$1")"
@@ -530,31 +541,33 @@ apply_path ()
 {
   local src="$1"; local dest="$2"; local target="$3"; local real="$4"; local line="$5"
 
-  # Make symlinks relative
+  # Make symlinks relative, if applicable
   if [ $COPY -eq 0 ]; then
-    local realpath=$($readlink_missing "${dest%/*}"); local commonpath=""
-    if [ "${dest%/*}" == "${realpath}" ]; then
-      # Use modman root as common path if destination is not itself a symlinked path
-      commonpath="${mmroot%/}"
-    else
-      # Search for longest common path as symlink target
-      for ((i=0; i<${#dest}; i++)); do
-        if [[ "${dest:i:1}" != "${realpath:i:1}" ]]; then
-          commonpath="${dest:0:i}"
-          commonpath="${commonpath%/*}"
-          break
-        fi
-      done
-    fi
-    # Replace destination (less common path) with ../*
-    if [ "$commonpath" != "" ]; then
-      local reldest="${dest#$commonpath/}"
-      if [ "$reldest" != "${reldest%/*}" ]; then
-        reldest=$(IFS=/; for d in ${reldest%/*}; do echo -n '../'; done)
+    if [ "$target" != "${target%/*}" ] && ! is_symlink_path "${target%/*}"; then
+      local realpath=$($readlink_missing "${dest%/*}"); local commonpath=""
+      if [ "${dest%/*}" == "${realpath}" ]; then
+        # Use modman root as common path if destination is not itself a symlinked path
+        commonpath="${mmroot%/}"
       else
-        reldest=""
+        # Search for longest common path as symlink target
+        for ((i=0; i<${#dest}; i++)); do
+          if [[ "${dest:i:1}" != "${realpath:i:1}" ]]; then
+            commonpath="${dest:0:i}"
+            commonpath="${commonpath%/*}"
+            break
+          fi
+        done
       fi
-      src="${reldest}${src#$commonpath/}"
+      # Replace destination (less common path) with ../*
+      if [ "$commonpath" != "" ]; then
+        local reldest="${dest#$commonpath/}"
+        if [ "$reldest" != "${reldest%/*}" ]; then
+          reldest=$(IFS=/; for d in ${reldest%/*}; do echo -n '../'; done)
+        else
+          reldest=""
+        fi
+        src="${reldest}${src#$commonpath/}"
+      fi
     fi
   fi
 


### PR DESCRIPTION
Example struct:
* testproject/
  * .modman/
    * a/
      * example/
      * modman
      ```
      example example
      ```
    * b/
      * example/ 
        * file
      * modman
      ```
      example/file example/file
      ```

Without the patch the project will contain these two symlinks:
* example => .modman/a/example
* example/file => ../.modman/b/example/file (broken symlink!)

The patch will change 2nd symlink to an absolute symlink.

Before you judge: Yes that's not a good project structure. I agree. But this also applies to symlinks not created by modman and pointing out of the project root. You may still not like it, but it shouldn't break any existing setups, only support more bad cases.
Lets pray for Magento 2.0 to end that mess ;)