### PR TITLE
preventing modman_get_module from freezing at autocomplete

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -59,23 +59,28 @@ _modman_get_mm()
  
 _modman_get_module()
 {
-	local root module modpath mm _pwd
-	_pwd=`pwd`
-	mm=$(_modman_get_mm)
-	[ -z "$mm" ] && return 1
-	root="$(dirname $mm)"
-	module=''
-	while [ "$root" != "$(pwd)" ]; do
-		modpath=`pwd`
-		if [ "$mm" = "$(dirname $modpath)" ]; then
-			module=$(basename $modpath)
-			break
-		fi
-		cd ..
-	done
-	cd $_pwd
-	[ -z "$module" ] && return 1
-	echo $module
+        local root module modpath mm _pwd
+        _pwd=`pwd`
+        mm=$(_modman_get_mm)
+        [ -z "$mm" ] && return 1
+        root="$(dirname $mm)"
+        module=''
+        i=0
+        while [ "$root" != "$(pwd)" ]; do
+                if [ "$i" -gt 5 ]; then
+                        break
+                fi
+                modpath=`pwd`
+                if [ "$mm" = "$(dirname $modpath)" ]; then
+                        module=$(basename $modpath)
+                        break
+                fi
+                cd ..
+                i=$((i+1))
+        done
+        cd $_pwd
+        [ -z "$module" ] && return 1
+        echo $module
 }
- 
+
 complete -F _modman modman


### PR DESCRIPTION
In some instances, this function keeps looping. The limit will prevent the user having to cancel the command.