### PR TITLE
Fixed infinite loop in _modman_get_module()

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -65,18 +65,13 @@ _modman_get_module()
         [ -z "$mm" ] && return 1
         root="$(dirname $mm)"
         module=''
-        i=0
-        while [ "$root" != "$(pwd)" ]; do
-                if [ "$i" -gt 5 ]; then
-                        break
-                fi
+        while [ "$root" != "$(pwd -P)" ]; do
                 modpath=`pwd`
                 if [ "$mm" = "$(dirname $modpath)" ]; then
                         module=$(basename $modpath)
                         break
                 fi
                 cd ..
-                i=$((i+1))
         done
         cd $_pwd
         [ -z "$module" ] && return 1

--- a/bash_completion
+++ b/bash_completion
@@ -45,7 +45,7 @@ _modman_get_mm()
 {
 	local root _pwd
 	_pwd=$(pwd)
-	root=$(pwd -P)
+	root=$_pwd
 	while ! [ -d $root/.modman ]; do
 		if [ "$root" = "/" ]; then
 			cd $_pwd && return 1
@@ -65,8 +65,11 @@ _modman_get_module()
         [ -z "$mm" ] && return 1
         root="$(dirname $mm)"
         module=''
-        while [ "$root" != "$(pwd -P)" ]; do
+        while [ "$root" != "$(pwd)" ]; do
                 modpath=`pwd`
+                if [ "$modpath" = "/" ]; then
+				        cd $_pwd && return 1
+                fi
                 if [ "$mm" = "$(dirname $modpath)" ]; then
                         module=$(basename $modpath)
                         break


### PR DESCRIPTION
$root is the real path with de-referenced symlinks while "$(pwd)" may contain symlinks
Reverted previous workaround