### PR TITLE
Fix relative symlinks for nested modules

### DIFF
--- a/modman
+++ b/modman
@@ -559,9 +559,10 @@ apply_path ()
     fi
     # Replace destination (less common path) with ../*
     if [ "$commonpath" != "" ]; then
-      local reldest="${dest#$commonpath/}"
-      if [ "$reldest" != "${reldest%/*}" ]; then
-        reldest=$(IFS=/; for d in ${reldest%/*}; do echo -n '../'; done)
+      local reldest="${realpath#$commonpath/}"
+      # test if the linkname is not just a filename without a path
+      if [ "$real" != "${real%/*}" ]; then
+        reldest=$(IFS=/; for d in ${reldest}; do echo -n '../'; done)
       else
         reldest=""
       fi


### PR DESCRIPTION
Dealing with [Fishpig](https://fishpig.co.uk/magento/wordpress-integration/), I encountered nested modules: Addons that link
into a previously linked module.

Example modman file for Fishpig_Wordpress:

    app/code/community/Fishpig/Wordpress app/code/community/Fishpig/Wordpress
    app/etc/modules/Fishpig_Wordpress.xml app/etc/modules/Fishpig_Wordpress.xml

Example modman file for Fishpig_Wordpress_Addon_ACF:

    app/code/community/Fishpig/Wordpress/Addon/ACF app/code/community/Fishpig/Wordpress/Addon/ACF
    app/etc/modules/Fishpig_Wordpress_Addon_ACF.xml app/etc/modules/Fishpig_Wordpress_Addon_ACF.xml

This would generate broken symlinks relative to the apparent (not the
real) path for the second module.

    ./.modman/Fishpig_Wordpress/app/code/community/Fishpig/Wordpress/Addon/ACF -> ../../../../../../.modman/Fishpig_Wordpress_Addon_ACF/app/code/community/Fishpig/Wordpress/Addon/ACF

By calculating the relative path from the real path this is fixed.