### PR TITLE
Bump version to 1.14

### DIFF
--- a/modman
+++ b/modman
@@ -21,7 +21,7 @@
 #    - The following common utilities must be locatable in your $PATH
 #       grep (POSIX), find, ln, cp, basename, dirname, readlink
 
-version="1.12"
+version="1.14"
 script=${0##*/}
 usage="\
 Module Manager (v$version)


### PR DESCRIPTION
A version `1.13` was released. Since then a bug was fixed, hence 1.14.

IMHO, it should be increased, feel free to discard.

Replaces #131.